### PR TITLE
feature_value_widgets/value_special_widget_x62.cpp: Add missing ()

### DIFF
--- a/src/feature_value_widgets/value_special_widget_x62.cpp
+++ b/src/feature_value_widgets/value_special_widget_x62.cpp
@@ -185,7 +185,7 @@ void ValueSpecialWidgetX62::combobox_activated(int index) {
    bool debug = false;
    debug = debug || debugWidget;
    TRACEMCF(debug, "feature 0x%02x, index=%d", _featureCode, index);
-   assert(_cb->currentIndex == index);
+   assert(_cb->currentIndex() == index);
 
    // QVariant qv = _cb->itemData(ndx);
    // uint i = qv.toUInt();


### PR DESCRIPTION
This fixes:

```
FAILED: CMakeFiles/ddcui.dir/src/feature_value_widgets/value_special_widget_x62.cpp.o 
/usr/bin/x86_64-pc-linux-gnu-g++ -DQT_CORE_LIB -DQT_GUI_LIB -DQT_NO_DEBUG -DQT_WIDGETS_LIB -I/var/tmp/portage/app-misc/ddcui-0.2.1/work/ddcui-0.2.1_build -I/var/tmp/portage/app-misc/ddcui-0.2.1/work/ddcui-0.2.1 -I/var/tmp/portage/app-misc/ddcui-0.2.1/work/ddcui-0.2.1_build/ddcui_autogen/include -I/var/tmp/portage/app-misc/ddcui-0.2.1/work/ddcui-0.2.1/src -isystem /usr/include/qt5 -isystem /usr/include/qt5/QtHelp -isystem /usr/include/qt5/QtWidgets -isystem /usr/include/qt5/QtGui -isystem /usr/include/qt5/QtCore -isystem /usr/lib64/qt5/mkspecs/linux-g++ -isystem /usr/include/qt5/QtSql -isystem /usr/include/glib-2.0 -isystem /usr/lib64/glib-2.0/include  -march=native -O2 -pipe -frecord-gcc-switches -fPIC -std=gnu++11 -MD -MT CMakeFiles/ddcui.dir/src/feature_value_widgets/value_special_widget_x62.cpp.o -MF CMakeFiles/ddcui.dir/src/feature_value_widgets/value_special_widget_x62.cpp.o.d -o CMakeFiles/ddcui.dir/src/feature_value_widgets/value_special_widget_x62.cpp.o -c /var/tmp/portage/app-misc/ddcui-0.2.1/work/ddcui-0.2.1/src/feature_value_widgets/value_special_widget_x62.cpp
In file included from /usr/include/qt5/QtCore/qglobal.h:50,
from /usr/include/qt5/QtGui/qtguiglobal.h:43,
from /usr/include/qt5/QtWidgets/qtwidgetsglobal.h:43,
from /usr/include/qt5/QtWidgets/qwidget.h:43,
from /usr/include/qt5/QtWidgets/QWidget:1,
from /var/tmp/portage/app-misc/ddcui-0.2.1/work/ddcui-0.2.1/src/core_widgets/enhanced_slider.h:10,
from /var/tmp/portage/app-misc/ddcui-0.2.1/work/ddcui-0.2.1/src/feature_value_widgets/value_special_widget_x62.cpp:9:
/var/tmp/portage/app-misc/ddcui-0.2.1/work/ddcui-0.2.1/src/feature_value_widgets/value_special_widget_x62.cpp: In member function ‘void ValueSpecialWidgetX62::combobox_activated(int)’:
/var/tmp/portage/app-misc/ddcui-0.2.1/work/ddcui-0.2.1/src/feature_value_widgets/value_special_widget_x62.cpp:188:16: error: invalid use of member function ‘int QComboBox::currentIndex() const’ (did you forget the ‘()’ ?)
188 |    assert(_cb->currentIndex == index);
|           ~~~~~^~~~~~~~~~~~
```

Signed-off-by: Andrew Ammerlaan <andrewammerlaan@gentoo.org>