### PR TITLE
Remove what maybe a copy and paste error at the end of the SPDX identifier

### DIFF
--- a/src/monitor_desc/monitor_desc_ui.h
+++ b/src/monitor_desc/monitor_desc_ui.h
@@ -1,7 +1,7 @@
 // monitor_desc_ui.h
 
 // Copyright (C) 2018-2019 Sanford Rockowitz <rockowitz@minsoft.com>
-// SPDX-License-Identifier: GPL-2.0-or-later/endcopyright>
+// SPDX-License-Identifier: GPL-2.0-or-later
 
 #ifndef MONITOR_DESC_UI_H_
 #define MONITOR_DESC_UI_H_


### PR DESCRIPTION
Remove what maybe a copy and paste error at the end of the SPDX identifier. Flags an error when using the 'licenserecon' license checking tool from Debian unstable (sid).

Regards

Phil